### PR TITLE
fix: align enhancer style with standards to wrap the middleware

### DIFF
--- a/src/mainStateSyncEnhancer.ts
+++ b/src/mainStateSyncEnhancer.ts
@@ -77,7 +77,7 @@ export const mainStateSyncEnhancer = (options = defaultMainOptions): StoreEnhanc
             dispatch,
         }
 
-        dispatch = compose<Dispatch>(middleware(middlewareAPI))(store.dispatch)
+        dispatch = compose<Dispatch>(middleware(middlewareAPI))(dispatch)
 
         return {
             ...store,

--- a/src/rendererStateSyncEnhancer.ts
+++ b/src/rendererStateSyncEnhancer.ts
@@ -66,7 +66,7 @@ export const rendererStateSyncEnhancer = (options = defaultRendererOptions): Sto
             dispatch,
         }
 
-        dispatch = compose<Dispatch>(middleware(middlewareAPI))(store.dispatch)
+        dispatch = compose<Dispatch>(middleware(middlewareAPI))(dispatch)
 
         return {
             ...store,

--- a/src/rendererStateSyncEnhancer.ts
+++ b/src/rendererStateSyncEnhancer.ts
@@ -1,10 +1,20 @@
 import { ipcRenderer } from 'electron'
-import { Action, applyMiddleware, Middleware, StoreCreator, StoreEnhancer } from 'redux'
+import {
+    Action,
+    compose,
+    Dispatch,
+    Middleware,
+    MiddlewareAPI,
+    StoreCreator,
+    StoreEnhancer,
+} from 'redux'
 import { IPCEvents } from './constants'
 import { fetchInitialState, fetchInitialStateAsync } from './fetchState'
 import { replaceState, withStoreReplacer } from './fetchState/replaceState'
-import { defaultRendererOptions, RendererStateSyncEnhancerOptions } from './options/RendererStateSyncEnhancerOptions'
-
+import {
+    defaultRendererOptions,
+    RendererStateSyncEnhancerOptions,
+} from './options/RendererStateSyncEnhancerOptions'
 import { preventDoubleInitialization, stopForwarding, validateAction } from './utils'
 
 const createMiddleware = (options: RendererStateSyncEnhancerOptions): Middleware => (store) => {
@@ -35,11 +45,12 @@ export const rendererStateSyncEnhancer = (options = defaultRendererOptions): Sto
     preventDoubleInitialization()
 
     return (reducer, state) => {
+        const middleware = createMiddleware(options)
+
         const initialState = options.lazyInit ? state : fetchInitialState<typeof state>(options)
         const store = createStore(
             options.lazyInit ? withStoreReplacer(reducer) : reducer,
-            initialState,
-            applyMiddleware(createMiddleware(options))
+            initialState
         )
 
         if (options.lazyInit) {
@@ -48,14 +59,18 @@ export const rendererStateSyncEnhancer = (options = defaultRendererOptions): Sto
             })
         }
 
-        // TODO: this needs some ❤️
-        // XXX: TypeScript is dumb. If you return the call to createStore
-        // immediately it's fine, but even assigning it to a constant and returning
-        // will make it freak out. We fix this with the line below the return.
-        return store
+        let dispatch = store.dispatch
 
-        // TODO: this needs some ❤️
-        // XXX: Even though this is unreachable, it fixes the type signature????
-        return (store as unknown) as any
+        const middlewareAPI: MiddlewareAPI<Dispatch<any>> = {
+            getState: store.getState,
+            dispatch,
+        }
+
+        dispatch = compose<Dispatch>(middleware(middlewareAPI))(store.dispatch)
+
+        return {
+            ...store,
+            dispatch,
+        }
     }
 }

--- a/tests/counter.ts
+++ b/tests/counter.ts
@@ -8,6 +8,7 @@ const init: CounterState = {
 
 const INCREMENT = 'INCREMENT'
 const DECREMENT = 'DECREMENT'
+const SET_COUNT_MIDDLEWARE = 'SET_COUNT_MIDDLEWARE'
 
 type IncrementAction = {
     type: typeof INCREMENT
@@ -17,7 +18,12 @@ type DecrementAction = {
     type: typeof DECREMENT
 }
 
-export type Actions = IncrementAction | DecrementAction
+type SetCountMiddlewareAction = {
+    type: typeof SET_COUNT_MIDDLEWARE
+    payload: number
+}
+
+export type Actions = IncrementAction | DecrementAction | SetCountMiddlewareAction
 
 export const reducer = (state = init, action: Actions): CounterState => {
     switch (action.type) {
@@ -25,6 +31,8 @@ export const reducer = (state = init, action: Actions): CounterState => {
             return { ...state, count: state.count + 1 }
         case DECREMENT:
             return { ...state, count: state.count - 1 }
+        case SET_COUNT_MIDDLEWARE:
+            return { ...state, count: action.payload }
         default:
             return state
     }

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -48,4 +48,37 @@ describe('End to End Tests', () => {
         // eslint-disable-next-line @typescript-eslint/await-thenable
         expect(await app.browserWindow.getTitle()).toEqual('9')
     })
+
+    it('should be able to increment value from main process', async () => {
+        expect(await getText('#value')).toEqual('10')
+        expect(await app.browserWindow.getTitle()).toEqual('10')
+
+        await click('#mainIncrement')
+
+        expect(await getText('#value')).toEqual('11')
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        expect(await app.browserWindow.getTitle()).toEqual('11')
+    })
+
+    it('should be able to use middleware when dispatching from renderer process', async () => {
+        expect(await getText('#value')).toEqual('10')
+        expect(await app.browserWindow.getTitle()).toEqual('10')
+
+        await click('#setCountMiddleware')
+
+        expect(await getText('#value')).toEqual('99')
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        expect(await app.browserWindow.getTitle()).toEqual('99')
+    })
+
+    it('should be able to use middleware when dispatching from main process', async () => {
+        expect(await getText('#value')).toEqual('10')
+        expect(await app.browserWindow.getTitle()).toEqual('10')
+
+        await click('#mainsetCountMiddleware')
+
+        expect(await getText('#value')).toEqual('99')
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        expect(await app.browserWindow.getTitle()).toEqual('99')
+    })
 })

--- a/tests/e2e/renderer/index.ts
+++ b/tests/e2e/renderer/index.ts
@@ -1,8 +1,13 @@
-import { createStore } from 'redux'
+import { applyMiddleware, compose, createStore } from 'redux'
 import { reducer } from '../../counter'
 import { rendererStateSyncEnhancer } from '../../../'
+import { countMiddleware } from '../../middleware'
+import { ipcRenderer } from 'electron'
 
-const store = createStore(reducer, rendererStateSyncEnhancer())
+const middleware = applyMiddleware(countMiddleware)
+const enhancer = compose(middleware, rendererStateSyncEnhancer())
+
+const store = createStore(reducer, enhancer)
 
 function mount() {
     document.getElementById('app')!.innerHTML = `
@@ -10,6 +15,10 @@ function mount() {
         Clicked: <span id="value">0</span> times </br>
         <button id="increment">+</button>
         <button id="decrement">-</button>
+
+        <button id="setCountMiddleware">#</button>
+        <button id="mainsetCountMiddleware">#</button>
+        <button id="mainIncrement">#</button>
       </p>
     `
 
@@ -19,6 +28,16 @@ function mount() {
 
     document.getElementById('decrement')!.addEventListener('click', () => {
         store.dispatch({ type: 'DECREMENT' })
+    })
+
+    document.getElementById('setCountMiddleware')!.addEventListener('click', () => {
+        store.dispatch({ type: 'SET_COUNT_MIDDLEWARE', payload: 9 })
+    })
+    document.getElementById('mainsetCountMiddleware')!.addEventListener('click', () => {
+        ipcRenderer.send('mainsetCountMiddleware')
+    })
+    document.getElementById('mainIncrement')!.addEventListener('click', () => {
+        ipcRenderer.send('mainIncrement')
     })
 }
 

--- a/tests/middleware.ts
+++ b/tests/middleware.ts
@@ -1,0 +1,8 @@
+import { Middleware } from 'redux'
+
+export const countMiddleware: Middleware = () => (next) => (action) => {
+    return next({
+        ...action,
+        payload: 99,
+    })
+}


### PR DESCRIPTION
As per my comments in #260. Unfortunately, I was unable to reproduce this using the tests, but in my setup using the `redux-observable` package I am having several issues. One of which is solved by aligning with the wrapping of middleware as used in the redux library itself. I think for some reason, in my case (some of) my middleware was overwritten by the middleware applied in the enhancer. Either way, my middleware was not properly executing, but after this fix, it is.

I did some extensive research but I was unable to find another library using a similar pattern of applying middleware in the enhancer instead of [redux](https://github.com/reduxjs/redux/blob/176e66adc9a90df2690620075e82dca21cc1cd25/src/applyMiddleware.ts#L66) itself, so I do not know if this is 100% correct. 