### PR TITLE
Unhandled error fix causing app crash on load

### DIFF
--- a/packages/electron-redux/src/middleware/forwardToRenderer.js
+++ b/packages/electron-redux/src/middleware/forwardToRenderer.js
@@ -1,23 +1,25 @@
-import { webContents } from 'electron';
-import validateAction from '../helpers/validateAction';
+import { webContents } from "electron";
+import validateAction from "../helpers/validateAction";
 
-const forwardToRenderer = () => next => (action) => {
+const forwardToRenderer = () => (next) => (action) => {
   if (!validateAction(action)) return next(action);
-  if (action.meta && action.meta.scope === 'local') return next(action);
+  if (action.meta && action.meta.scope === "local") return next(action);
 
   // change scope to avoid endless-loop
   const rendererAction = {
     ...action,
     meta: {
       ...action.meta,
-      scope: 'local',
+      scope: "local",
     },
   };
-
+  if (!webContents) {
+    return next(action);
+  }
   const allWebContents = webContents.getAllWebContents();
 
   allWebContents.forEach((contents) => {
-    contents.send('redux-action', rendererAction);
+    contents.send("redux-action", rendererAction);
   });
 
   return next(action);


### PR DESCRIPTION
Accessing webcontents in case it does not exists crashes the app with unhandled exception and users of this library have a hard time to figure why. 
The fix is, in case webcontent is not defined, continue with next reducer and skip forward to ui, since there is no ui yet.