### PR TITLE
use ipcRenderer.sendSync instead of remote.getGlobal

### DIFF
--- a/packages/electron-redux/src/__mocks__/electron.js
+++ b/packages/electron-redux/src/__mocks__/electron.js
@@ -11,8 +11,5 @@ export const ipcMain = {
 export const ipcRenderer = {
   on: jest.fn(),
   send: jest.fn(),
-};
-
-export const remote = {
-  getGlobal: jest.fn(),
+  sendSync: jest.fn(),
 };

--- a/packages/electron-redux/src/helpers/__tests__/getInitialStateRenderer.js
+++ b/packages/electron-redux/src/helpers/__tests__/getInitialStateRenderer.js
@@ -1,4 +1,4 @@
-import { remote } from 'electron';
+import { ipcRenderer } from 'electron';
 import getInitialStateRenderer from '../getInitialStateRenderer';
 
 jest.unmock('../getInitialStateRenderer');
@@ -6,7 +6,7 @@ jest.unmock('../getInitialStateRenderer');
 describe('getInitialStateRenderer', () => {
   it('should return the initial state', () => {
     const state = { foo: 456 };
-    remote.getGlobal.mockImplementation(() => () => JSON.stringify(state));
+    ipcRenderer.sendSync.mockImplementation(() => JSON.stringify(state));
 
     expect(getInitialStateRenderer()).toEqual(state);
   });

--- a/packages/electron-redux/src/helpers/__tests__/replayActionMain.js
+++ b/packages/electron-redux/src/helpers/__tests__/replayActionMain.js
@@ -4,45 +4,47 @@ import replayActionMain from '../replayActionMain';
 jest.unmock('../replayActionMain');
 
 describe('replayActionMain', () => {
+  const store = {
+    dispatch: jest.fn(),
+    getState: jest.fn(),
+    subscribe: jest.fn(),
+  };
+
+  replayActionMain(store);
+
   it('should replay any actions received', () => {
-    const store = {
-      dispatch: jest.fn(),
-      getState: jest.fn(),
-      subscribe: jest.fn(),
-    };
     const payload = 123;
 
-    replayActionMain(store);
+    expect(ipcMain.on).toHaveBeenCalledTimes(2);
+    expect(ipcMain.on.mock.calls[1][0]).toBe('redux-action');
+    expect(ipcMain.on.mock.calls[1][1]).toBeInstanceOf(Function);
 
-    expect(ipcMain.on).toHaveBeenCalledTimes(1);
-    expect(ipcMain.on.mock.calls[0][0]).toBe('redux-action');
-    expect(ipcMain.on.mock.calls[0][1]).toBeInstanceOf(Function);
-
-    const cb = ipcMain.on.mock.calls[0][1];
+    const cb = ipcMain.on.mock.calls[1][1];
     cb('someEvent', payload);
 
     expect(store.dispatch).toHaveBeenCalledTimes(1);
     expect(store.dispatch).toHaveBeenCalledWith(payload);
   });
 
-  it('should return the current state from the global', () => {
+  it('should reply current state', () => {
     const initialState = { initial: 'state' };
     const newState = { new: 'state' };
-    const store = {
-      dispatch: jest.fn(),
-      getState: jest.fn(),
-      subscribe: jest.fn(),
-    };
 
     store.getState.mockReturnValueOnce(initialState);
     store.getState.mockReturnValueOnce(newState);
 
-    replayActionMain(store);
+    expect(ipcMain.on.mock.calls[0][0]).toBe('get-redux-state');
+    expect(ipcMain.on.mock.calls[0][1]).toBeInstanceOf(Function);
 
-    expect(global.getReduxState()).toEqual(JSON.stringify(initialState));
+    const cb = ipcMain.on.mock.calls[0][1];
+    const event = { returnValue: '' };
+    cb(event);
+
+    expect(event.returnValue).toEqual(JSON.stringify(initialState));
     expect(store.getState).toHaveBeenCalledTimes(1);
 
-    expect(global.getReduxState()).toEqual(JSON.stringify(newState));
+    cb(event);
+    expect(event.returnValue).toEqual(JSON.stringify(newState));
     expect(store.getState).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/electron-redux/src/helpers/__tests__/replayActionMain.js
+++ b/packages/electron-redux/src/helpers/__tests__/replayActionMain.js
@@ -4,16 +4,19 @@ import replayActionMain from '../replayActionMain';
 jest.unmock('../replayActionMain');
 
 describe('replayActionMain', () => {
-  const store = {
-    dispatch: jest.fn(),
-    getState: jest.fn(),
-    subscribe: jest.fn(),
-  };
-
-  replayActionMain(store);
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   it('should replay any actions received', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: jest.fn(),
+      subscribe: jest.fn(),
+    };
     const payload = 123;
+
+    replayActionMain(store);
 
     expect(ipcMain.on).toHaveBeenCalledTimes(2);
     expect(ipcMain.on.mock.calls[1][0]).toBe('redux-action');
@@ -27,12 +30,21 @@ describe('replayActionMain', () => {
   });
 
   it('should reply current state', () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: jest.fn(),
+      subscribe: jest.fn(),
+    };
+
     const initialState = { initial: 'state' };
     const newState = { new: 'state' };
+
+    replayActionMain(store);
 
     store.getState.mockReturnValueOnce(initialState);
     store.getState.mockReturnValueOnce(newState);
 
+    expect(ipcMain.on).toHaveBeenCalledTimes(2);
     expect(ipcMain.on.mock.calls[0][0]).toBe('get-redux-state');
     expect(ipcMain.on.mock.calls[0][1]).toBeInstanceOf(Function);
 

--- a/packages/electron-redux/src/helpers/getInitialStateRenderer.js
+++ b/packages/electron-redux/src/helpers/getInitialStateRenderer.js
@@ -1,11 +1,11 @@
-import { remote } from 'electron';
+import { ipcRenderer } from 'electron';
 
 export default function getInitialStateRenderer() {
-  const getReduxState = remote.getGlobal('getReduxState');
-  if (!getReduxState) {
+  const reduxState = ipcRenderer.sendSync('get-redux-state');
+  if (!reduxState) {
     throw new Error(
       'Could not find reduxState global in main process, did you forget to call replayActionMain?',
     );
   }
-  return JSON.parse(getReduxState());
+  return JSON.parse(reduxState);
 }

--- a/packages/electron-redux/src/helpers/replayActionMain.js
+++ b/packages/electron-redux/src/helpers/replayActionMain.js
@@ -8,7 +8,9 @@ export default function replayActionMain(store) {
    *
    * Refer to https://github.com/electron/electron/blob/master/docs/api/remote.md#remote-objects
    */
-  global.getReduxState = () => JSON.stringify(store.getState());
+  ipcMain.on('get-redux-state', (event) => {
+    event.returnValue = JSON.stringify(store.getState());
+  });
 
   ipcMain.on('redux-action', (event, payload) => {
     store.dispatch(payload);


### PR DESCRIPTION
As of electron v10, enableRemoteMoudle is set to false by default, and I had to enable it for this library.
And from v12, remote module was deprecated for security reason and it started to show warning message on devTools console.
I found that getInitialStateRenderer is using remote.getGlobal so I substitute ipcRenderer.sendSync to it.